### PR TITLE
docs(agents): add AGENTS guides across monorepo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# AGENTS.md
+
+**Generated:** 2026-03-23 | **Commit:** 89328ad | **Branch:** main
+
+## OVERVIEW
+
+Polyglot AI/LLM experimentation monorepo — LangChain-based copilot experiments. Contains a production-ish Flask + SvelteKit PDF chat app (`course/pdf-dist`) and standalone Python/TypeScript tutorial scripts. Course/exploration code, not a shipped product.
+
+**Stack:** Python 3.11.7 (Poetry) · TypeScript 5.3 (pnpm) · Flask · SvelteKit · LangChain (old 0.0.x) · OpenAI · Pinecone · Redis · Celery · SQLAlchemy
+
+## STRUCTURE
+
+```
+copiloting/
+├── tutorials/           # TS LangChain tutorial scripts (pnpm workspace)
+├── course/
+│   ├── sections/        # Python AI modules: agents, chains, facts, tchat (Poetry pkg)
+│   ├── pdf-dist/        # Flask PDF chat app + SvelteKit frontend (standalone)
+│   │   ├── app/         # Python backend
+│   │   │   ├── chat/    # LLM chains, retrievers, memory, embeddings, tracing
+│   │   │   └── web/     # Flask views, DB models, API helpers
+│   │   └── client/      # SvelteKit frontend (pnpm workspace)
+│   └── local-do/        # Minimal Flask PDF upload server
+├── copiloting/          # Empty Python stub (ignore)
+├── package.json         # Root pnpm workspace + Prettier scripts
+├── pyproject.toml       # Root Poetry config — defines CLI entry points
+├── pnpm-workspace.yaml  # JS workspaces: tutorials, course/pdf-dist/client
+└── tsconfig.json        # Extends @tsconfig/strictest, ES2022, nodenext
+```
+
+## WHERE TO LOOK
+
+| Task                    | Location                                                   |
+| ----------------------- | ---------------------------------------------------------- |
+| LangChain TS tutorial   | `tutorials/quickstart-llms.ts`                             |
+| Flask app factory       | `course/pdf-dist/app/web/__init__.py`                      |
+| LLM chat orchestration  | `course/pdf-dist/app/chat/chat.py`                         |
+| SvelteKit routes/pages  | `course/pdf-dist/client/src/routes/`                       |
+| Svelte components       | `course/pdf-dist/client/src/components/`                   |
+| Svelte state management | `course/pdf-dist/client/src/store/`                        |
+| Axios API client        | `course/pdf-dist/client/src/api/axios.ts`                  |
+| Python AI section demos | `course/sections/` (agents, chain, facts, tchat)           |
+| Flask DB models         | `course/pdf-dist/app/web/db/models/`                       |
+| Celery worker           | `course/pdf-dist/app/celery/worker.py`                     |
+| Env vars                | `.env.template` (safe) / `.env` (real keys — do not share) |
+| CI pipeline             | `.github/workflows/ci.yaml`                                |
+
+## CONVENTIONS
+
+- **TypeScript**: Extends `@tsconfig/strictest` — maximum strictness; no `any`, no suppression
+- **Module format**: `"module": "nodenext"` — requires `.js` extensions in TS imports
+- **Prettier**: `singleQuote: true`, `bracketSpacing: false`, `tabWidth: 2`; `.svelte` files use svelte parser
+- **Python**: pinned to `3.11.7`, managed by Poetry; each subdirectory is an independent Poetry project
+- **Package manager**: pnpm `≥7` only for JS/TS — never npm or yarn in this repo
+- **Line endings**: LF, enforced by EditorConfig across all files
+- **SvelteKit path aliases**: `$c` → `src/components`, `$s` → `src/store`, `$api` → `src/api/axios.js`
+
+## ANTI-PATTERNS
+
+- **`.env` contains real committed secrets** — never copy or commit actual API keys
+- **LangChain versions are ancient**: JS at `0.0.212`, Python at `0.0.352` — modern LangChain docs don't apply; imports and APIs are completely different
+- **No tests** — `pnpm test` intentionally exits with error; no pytest setup exists
+- **`copiloting/__init__.py`** is an empty stub — not a real importable package
+
+## COMMANDS
+
+```bash
+# From repo root — JS/TS
+pnpm install --frozen-lockfile       # install all workspaces
+pnpm build                           # build all workspaces recursively
+pnpm check-format                    # Prettier format check (runs in CI)
+pnpm format                          # Prettier auto-fix
+
+# Run TypeScript tutorial (requires SERPAPI_API_KEY + OPENAI_API_KEY in .env)
+pnpm -C tutorials run start:quickstart-llms
+
+# SvelteKit dev server
+pnpm -C course/pdf-dist/client run dev
+
+# From repo root — Python
+poetry install                       # install all Python deps
+poetry run agents                    # SQL agent demo (course/sections/agents)
+poetry run course                    # LangChain chain demo (course/sections/chain)
+poetry run facts                     # facts RAG demo (course/sections/facts)
+poetry run facts-create-embeddings   # create Chroma embeddings
+poetry run tchat                     # terminal chat demo
+```
+
+## NOTES
+
+- Renovate auto-updates deps; CI action pins use full SHA hashes (security practice)
+- CI runs format check + build for Node, `poetry install` only for Python (no lint/test)
+- `poetry.lock` (388KB) covers all Poetry groups including `pdf-dist` and `sections` path deps
+- Both `pnpm` and `poetry` run independently — no cross-language tooling bridge
+- `course/pdf-dist` has its own `dump.rdb` and `instance/sqlite.db` — local dev state artifacts

--- a/course/local-do/AGENTS.md
+++ b/course/local-do/AGENTS.md
@@ -1,0 +1,34 @@
+# course/local-do/AGENTS.md
+
+## OVERVIEW
+
+Minimal standalone Flask server for PDF upload only. No LLM integration — just a file receiver with UUID-named storage. Independent Poetry project.
+
+## STRUCTURE
+
+```
+local-do/
+├── app.py          # Flask app: single upload endpoint, saves to uploads/
+├── uploads/        # Uploaded PDFs stored with UUID filenames (gitkeep + real files)
+├── dump.rdb        # Redis dump (local dev artifact — ignore)
+├── pyproject.toml  # Standalone Poetry project (Flask, blinker, click)
+└── readme.md       # Brief description
+```
+
+## WHERE TO LOOK
+
+| Task            | Location                              |
+| --------------- | ------------------------------------- |
+| Upload endpoint | `app.py`                              |
+| File storage    | `uploads/` (UUID-named, no extension) |
+
+## CONVENTIONS
+
+- Standalone Poetry project — does NOT share deps with parent `pyproject.toml`
+- Uploaded files are stored without extension using UUID4 as filename
+
+## NOTES
+
+- `uploads/` contains real uploaded files committed to the repo (sample data from local dev)
+- `dump.rdb` is a Redis snapshot artifact — local dev only, not used in code here
+- No routes beyond file upload; no authentication

--- a/course/pdf-dist/AGENTS.md
+++ b/course/pdf-dist/AGENTS.md
@@ -1,0 +1,68 @@
+# course/pdf-dist/AGENTS.md
+
+## OVERVIEW
+
+Standalone Flask + SvelteKit PDF chat application. Users upload PDFs, which get embedded into Pinecone; conversations are LangChain RAG chains with configurable LLM/memory/retriever per-conversation. Background processing via Celery + Redis.
+
+**Stack:** Flask · SQLAlchemy (SQLite) · Celery · Redis · Pinecone · LangFuse · SvelteKit (built static)
+
+## STRUCTURE
+
+```
+pdf-dist/
+├── app/             # Python Flask backend (Poetry package)
+│   ├── chat/        # LLM orchestration: chains, memory, vectorstores, embeddings
+│   └── web/         # Flask app factory, routes, DB models, API helpers
+├── client/          # SvelteKit frontend (pnpm workspace, builds to client/build/)
+├── tasks.py         # Invoke task definitions (dev, devworker commands)
+├── pyproject.toml   # Standalone Poetry project
+├── dump.rdb         # Redis snapshot (local dev artifact)
+└── instance/        # SQLite DB lives here (local dev artifact)
+    └── sqlite.db
+```
+
+## WHERE TO LOOK
+
+| Task                   | Location                                                               |
+| ---------------------- | ---------------------------------------------------------------------- |
+| Flask app factory      | `app/web/__init__.py` — `create_app()`                                 |
+| LLM chat entry point   | `app/chat/chat.py` — `build_chat()`                                    |
+| PDF embedding pipeline | `app/chat/create_embeddings.py`, `app/web/tasks/embeddings.py`         |
+| Celery worker          | `app/celery/worker.py`                                                 |
+| DB init command        | `flask --app app.web init-db` (registered in `app/web/db/__init__.py`) |
+| Dev run tasks          | `tasks.py` — `inv dev`, `inv devworker`                                |
+
+## CONVENTIONS
+
+- Flask static files served from `client/build/` — SvelteKit adapter-static output
+- Celery only initialized if `Config.CELERY["broker_url"]` is set
+- All DB models inherit from `app.web.db.models.base.BaseModel`
+- Conversation components (LLM name, retriever name, memory name) stored in `Conversation` model and selected via weighted random scoring (`app/chat/score.py`)
+
+## ANTI-PATTERNS
+
+- Do not use `pip install` — this is a Poetry project (`poetry install` from repo root)
+- Flask app uses `langchain==0.0.x` — modern langchain chain APIs don't apply here
+- `instance/sqlite.db` and `dump.rdb` are local dev artifacts — not production state
+
+## COMMANDS
+
+```bash
+# DB setup (first time)
+flask --app app.web init-db
+
+# Dev (three separate terminals)
+inv dev           # Flask server
+inv devworker     # Celery worker
+redis-server      # Redis
+
+# SvelteKit frontend
+pnpm -C course/pdf-dist/client run dev    # from repo root
+pnpm -C course/pdf-dist/client run build  # build static assets to client/build/
+```
+
+## NOTES
+
+- `client/build/` is served as Flask static folder — run `pnpm build` in client before deploying
+- LangFuse tracing is optional — only activated if `LANGFUSE_PUBLIC_KEY`/`SECRET_KEY` are set
+- Conversation component selection uses weighted scoring to A/B test different LLM/retriever combos

--- a/course/pdf-dist/app/chat/AGENTS.md
+++ b/course/pdf-dist/app/chat/AGENTS.md
@@ -1,0 +1,69 @@
+# course/pdf-dist/app/chat/AGENTS.md
+
+## OVERVIEW
+
+LLM orchestration layer — builds RAG chains with pluggable LLM, memory, and retriever strategies. All LangChain interaction lives here; Flask layer never touches LangChain directly.
+
+## STRUCTURE
+
+```
+chat/
+├── chat.py              # Entry: build_chat() — selects + wires components
+├── chains/
+│   ├── retrieval.py     # RetrievalChain: TraceableChain + StreamableChain + ConversationalRetrievalChain
+│   ├── streamable.py    # Mixin: SSE streaming support
+│   └── traceable.py     # Mixin: LangFuse tracing support
+├── memory/
+│   ├── sql_memory.py    # Conversation memory backed by SQLAlchemy
+│   ├── window_memory.py # Sliding window memory
+│   └── history/
+│       └── sql_history.py  # Message history adapter for SQL storage
+├── vectorstores/
+│   └── pinecone.py      # Pinecone retriever builder
+├── embeddings/
+│   └── openai.py        # OpenAI embeddings builder
+├── llms/
+│   └── chat_openai.py   # ChatOpenAI LLM builder (returns map entry)
+├── callbacks/
+│   └── stream.py        # Streaming callback handler for SSE
+├── tracing/
+│   └── langfuse.py      # LangFuse callback + handler setup
+├── redis.py             # Redis client (used for rate-limiting / caching)
+├── score.py             # Weighted random component selection by A/B score
+├── models/__init__.py   # ChatArgs dataclass
+└── create_embeddings.py # PDF → embeddings → Pinecone upload pipeline
+```
+
+## WHERE TO LOOK
+
+| Task                    | Location                                            |
+| ----------------------- | --------------------------------------------------- |
+| Chat chain construction | `chat.py` → `build_chat()`                          |
+| Chain class definition  | `chains/retrieval.py` — `RetrievalChain`            |
+| Add streaming support   | `chains/streamable.py`                              |
+| Add LangFuse tracing    | `chains/traceable.py` + `tracing/langfuse.py`       |
+| Add new LLM option      | `llms/chat_openai.py` — add to `llm_map`            |
+| Add new memory type     | `memory/` — add builder to `memory_map`             |
+| Add new retriever       | `vectorstores/pinecone.py` — add to `retriever_map` |
+| ChatArgs input shape    | `models/__init__.py`                                |
+| A/B scoring logic       | `score.py`                                          |
+| PDF embedding pipeline  | `create_embeddings.py`                              |
+
+## CONVENTIONS
+
+- `llm_map`, `memory_map`, `retriever_map` — dicts mapping component name → builder function; `select_component()` picks from these using weighted scoring
+- Component names are stored in the `Conversation` DB record; reused on subsequent messages to same conversation
+- `ChatArgs` carries `conversation_id`, `pdf_id`, `metadata`, `streaming: bool`
+- `TraceableChain` + `StreamableChain` applied as mixins before `ConversationalRetrievalChain` in MRO
+- langchain 0.0.352 Python — use `from langchain.chat_models import ChatOpenAI`, NOT `from langchain_openai import ...`
+
+## ANTI-PATTERNS
+
+- Do not import from `langchain_openai`, `langchain_community`, etc. — those packages don't exist at `0.0.352`
+- Do not bypass `build_chat()` — component selection + persistence must go through it
+- Do not call DB layer directly from chat — use `app.web.api` functions
+
+## NOTES
+
+- `ChatOpenAI(streaming=False)` is used for the condense-question step even when streaming is enabled
+- LangFuse tracing is opt-in via env var presence

--- a/course/pdf-dist/app/web/AGENTS.md
+++ b/course/pdf-dist/app/web/AGENTS.md
@@ -1,0 +1,65 @@
+# course/pdf-dist/app/web/AGENTS.md
+
+## OVERVIEW
+
+Flask web layer — app factory, routes (blueprints), DB models (SQLAlchemy), auth hooks, and API helper functions used by both views and chat layer.
+
+## STRUCTURE
+
+```
+web/
+├── __init__.py       # App factory: create_app(), registers extensions/blueprints/hooks
+├── api.py            # DB helper functions (messages, conversations) used by chat layer
+├── hooks.py          # before_request: load_logged_in_user; error handler
+├── config/           # Config object loaded from env vars
+│   └── __init__.py
+├── db/
+│   ├── __init__.py   # SQLAlchemy db object + init_db_command CLI
+│   └── models/
+│       ├── base.py      # BaseModel with shared CRUD helpers
+│       ├── user.py      # User (UUID PK, email, password, relationships)
+│       ├── pdf.py       # Pdf (linked to user, tracks embedding status)
+│       ├── conversation.py  # Conversation (stores llm/memory/retriever component names)
+│       ├── message.py   # Message (role, content, linked to conversation)
+│       └── __init__.py  # Re-exports all models
+├── files.py          # File upload helpers (PDF validation, save to disk)
+├── views/
+│   ├── auth_views.py          # /auth/signin, /signup, /signout
+│   ├── pdf_views.py           # /api/pdfs — upload, list, get
+│   ├── conversation_views.py  # /api/conversations — CRUD + messaging
+│   ├── score_views.py         # /api/scores — A/B test component scoring
+│   └── client_views.py        # Catch-all: serves SvelteKit build for all non-API routes
+└── tasks/
+    └── embeddings.py  # Celery task: process PDF → create embeddings → store in Pinecone
+```
+
+## WHERE TO LOOK
+
+| Task                     | Location                                                                                                       |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Add a new Flask route    | `views/` — create blueprint function, register in `__init__.py`                                                |
+| DB models                | `db/models/` — each model has `create()`, `find_by()`, `update()` from BaseModel                               |
+| Auth (current user)      | `hooks.py` — `load_logged_in_user` sets `g.user`                                                               |
+| Config / env vars        | `config/__init__.py`                                                                                           |
+| PDF upload handling      | `files.py` + `views/pdf_views.py`                                                                              |
+| Background embedding job | `tasks/embeddings.py` (dispatched via Celery)                                                                  |
+| API helpers for chat     | `api.py` — `get_messages_by_conversation_id`, `add_message_to_conversation`, `get/set_conversation_components` |
+
+## CONVENTIONS
+
+- All models extend `BaseModel` — shared `create()`, `find_by()`, `update()`, `delete()` methods
+- `db.session` used directly in `api.py` — no repository pattern
+- Flask blueprints registered in `register_blueprints()` in `__init__.py`
+- `client_views.py` is the SPA fallback — returns `client/build/index.html` for unmatched routes
+- `g.user` populated by `load_logged_in_user` before every request
+
+## ANTI-PATTERNS
+
+- Do not call LangChain from views — all LLM work goes through `app.chat`
+- Do not bypass `BaseModel` for DB ops — use `Model.create()`, `.find_by()`, `.update()`
+- Do not import from `app.web.db.models` submodules directly — use the re-export in `models/__init__.py`
+
+## NOTES
+
+- `flask --app app.web init-db` drops + recreates all tables (destructive)
+- `Conversation` model stores `llm`, `memory`, `retriever` string names — used for A/B component selection

--- a/course/pdf-dist/client/AGENTS.md
+++ b/course/pdf-dist/client/AGENTS.md
@@ -1,0 +1,84 @@
+# course/pdf-dist/client/AGENTS.md
+
+## OVERVIEW
+
+SvelteKit frontend for the PDF chat app. Communicates with Flask backend via axios (`/api/*`). Built as static site (adapter-static) and served by Flask from `client/build/`. Uses Svelte 5 + Tailwind + Preline UI.
+
+## STRUCTURE
+
+```
+client/src/
+├── routes/                     # SvelteKit file-based routing
+│   ├── +layout.svelte          # Root layout: Navbar + auth guard
+│   ├── +layout.ts              # Load function: fetch user role
+│   ├── +page.svelte            # Home/redirect page
+│   ├── auth/                   # signin, signout, signup pages
+│   ├── chat/+page.svelte       # Main chat UI
+│   ├── documents/              # PDF list, upload, single PDF view ([id])
+│   └── scores/+page.svelte     # A/B score visualization (BarChart)
+├── components/
+│   ├── chat/                   # ChatPanel, ChatList, ChatInput, messages, ConversationSelect
+│   ├── auth/                   # AuthLinks
+│   └── {Alert, AuthGuard, BarChart, Button, FormGroup, Icon, Navbar,
+│          PdfViewer, Progress, TextInput, ErrorMessage, ErrorModal}.svelte
+├── store/
+│   ├── auth.ts                 # Auth state (user session)
+│   ├── chat/                   # Chat state: store.ts, stream.ts, sync.ts, index.ts
+│   ├── documents.ts            # PDF list state
+│   ├── errors.ts               # Global error store (addError)
+│   ├── role.ts                 # User role store
+│   ├── scores.ts               # A/B score data
+│   ├── store.ts                # Root Svelte store exports
+│   └── writeable.ts            # Base writable store helpers
+└── api/
+    └── axios.ts                # Axios instance (/api base URL) + error interceptor
+```
+
+## WHERE TO LOOK
+
+| Task              | Location                                                    |
+| ----------------- | ----------------------------------------------------------- |
+| Page routes       | `src/routes/` — SvelteKit `+page.svelte` files              |
+| Chat UI           | `src/routes/chat/+page.svelte` + `src/components/chat/`     |
+| PDF management UI | `src/routes/documents/`                                     |
+| API calls         | `src/api/axios.ts` — `api` instance; use `api.get/post/...` |
+| Global errors     | `src/store/errors.ts` — `addError()`                        |
+| Auth state        | `src/store/auth.ts`                                         |
+| Streaming chat    | `src/store/chat/stream.ts`                                  |
+
+## CONVENTIONS
+
+- **Path aliases** (do not use relative paths for these):
+  - `$c` → `src/components`
+  - `$s` → `src/store`
+  - `$api` → `src/api/axios.js`
+- All API calls use the `api` axios instance from `$api` — never raw `fetch` for backend
+- Tailwind for styling; Preline for UI components; Material Icons for icons
+- `svelte-check` for type checking — run `pnpm check` to validate
+- ESLint + Prettier enforced; `.svelte` files use svelte parser (tabWidth 2)
+- Adapter-static with `fallback: 'index.html'` — SPA routing handled by Flask catch-all
+
+## ANTI-PATTERNS
+
+- Do not use raw `fetch` for `/api/*` calls — use the `api` axios instance
+- Do not import from `src/store` using relative paths — use `$s/...`
+- Do not import from `src/components` using relative paths — use `$c/...`
+- Do not import from `src/api/axios.ts` using relative paths — use `$api`
+- Do not build with `npm` or `yarn` — this is a pnpm workspace
+
+## COMMANDS
+
+```bash
+# From repo root
+pnpm -C course/pdf-dist/client run dev      # dev server (requires Flask running)
+pnpm -C course/pdf-dist/client run build    # build static → client/build/
+pnpm -C course/pdf-dist/client run check    # svelte-check type validation
+pnpm -C course/pdf-dist/client run lint     # Prettier + ESLint check
+```
+
+## NOTES
+
+- `build/` output is committed and served by Flask — run `pnpm build` before deploying
+- Chat supports both streaming (SSE via `@microsoft/fetch-event-source`) and sync modes
+- `PdfViewer` uses `pdfjs-dist` for in-browser PDF rendering
+- Svelte 5 (5.54.0) — uses runes-era APIs if any new components are added

--- a/course/sections/AGENTS.md
+++ b/course/sections/AGENTS.md
@@ -1,0 +1,65 @@
+# course/sections/AGENTS.md
+
+## OVERVIEW
+
+Python AI section demo modules — four standalone LangChain demos exposed as Poetry CLI scripts. Each submodule is a self-contained experiment.
+
+## STRUCTURE
+
+```
+sections/
+├── agents/          # SQL agent — queries SQLite via LangChain OpenAIFunctionsAgent
+│   ├── __init__.py  # Entry point: builds agent + executor, runs two example queries
+│   ├── tools/       # Custom tools: sql.py (describe/query), report.py (write HTML)
+│   └── handlers/    # ChatModelStartHandler — logs LLM calls to console
+├── chain/           # SequentialChain demo: code generation → test generation
+│   └── __init__.py  # CLI with --task and --language args
+├── facts/           # RAG demo with Chroma vector store
+│   ├── __init__.py  # Entry: loads embeddings, runs retrieval QA chain
+│   ├── facts.txt    # Source document for RAG
+│   ├── redundant_filter_retriever.py  # Custom retriever deduplicating results
+│   ├── scores.ipynb # Jupyter notebook for scoring experiments
+│   └── .embeddings/ # Persisted Chroma DB (local dev artifact)
+├── tchat/           # Terminal chat loop
+│   └── __init__.py  # Interactive REPL using LangChain chat model
+└── utilities/       # Shared helpers
+    └── __init__.py
+```
+
+## WHERE TO LOOK
+
+| Task                    | Location                                                    |
+| ----------------------- | ----------------------------------------------------------- |
+| SQL agent with tools    | `agents/__init__.py` + `agents/tools/`                      |
+| SequentialChain example | `chain/__init__.py`                                         |
+| RAG with Chroma         | `facts/__init__.py` + `facts/redundant_filter_retriever.py` |
+| Custom LLM callback     | `agents/handlers/chat_model_start_handler.py`               |
+| Shared utilities        | `utilities/__init__.py`                                     |
+
+## CONVENTIONS
+
+- All modules use `langchain==0.0.352` (Python) — not compatible with modern langchain 0.1+/0.3+ APIs
+- `load_dotenv()` called at module init — reads from root `.env`
+- Each module is runnable via `poetry run <script>` from repo root (defined in root `pyproject.toml`)
+- SQLite DB for agents demo: `agents/db.sqlite`
+
+## ANTI-PATTERNS
+
+- Do not use modern langchain imports (`from langchain_openai import ...`) — only `langchain.llms.openai`, `langchain.chat_models`, etc. work at `0.0.352`
+- Do not add new Poetry scripts here — they're declared in root `pyproject.toml`, not this `pyproject.toml`
+
+## COMMANDS
+
+```bash
+# From repo root
+poetry run agents                  # SQL agent demo
+poetry run course                  # LangChain chain demo
+poetry run facts                   # facts RAG demo (needs embeddings first)
+poetry run facts-create-embeddings # create Chroma embeddings into facts/.embeddings/
+poetry run tchat                   # terminal chat
+```
+
+## NOTES
+
+- `facts/.embeddings/` contains persisted Chroma SQLite — delete to force rebuild
+- `agents/db.sqlite` is a pre-populated local SQLite DB for the SQL agent demo

--- a/tutorials/AGENTS.md
+++ b/tutorials/AGENTS.md
@@ -1,0 +1,50 @@
+# tutorials/AGENTS.md
+
+## OVERVIEW
+
+TypeScript LangChain tutorial — single script demonstrating LLM agent with web search + calculator. pnpm workspace package.
+
+## STRUCTURE
+
+```
+tutorials/
+├── quickstart-llms.ts   # Only tutorial: OpenAI LLM + SerpAPI + Calculator agent
+├── tsconfig.json        # Extends root tsconfig (ES2022, nodenext, strictest)
+├── package.json         # @copiloting/tutorials — build: rimraf + tsc
+└── dist/                # Compiled output (generated, don't edit)
+```
+
+## WHERE TO LOOK
+
+| Task        | Location                                                    |
+| ----------- | ----------------------------------------------------------- |
+| Agent setup | `quickstart-llms.ts` — `initializeAgentExecutorWithOptions` |
+| Tool config | `quickstart-llms.ts` — SerpAPI + Calculator instantiation   |
+| Run script  | `package.json` → `start:quickstart-llms`                    |
+
+## CONVENTIONS
+
+- Imports use `.js` extensions on runtime paths (nodenext module resolution)
+- langchain version pinned at `0.0.212` at root — do **not** use modern langchain APIs
+- `dotenv` loaded via `node -r dotenv/config` at runtime, not imported in code
+- Top-level `await` works because `"type": "module"` in package.json
+
+## ANTI-PATTERNS
+
+- Do not upgrade langchain imports without checking root `package.json` — old API
+- Do not add `import 'dotenv/config'` — injected at runtime via node flag
+
+## COMMANDS
+
+```bash
+# From repo root
+pnpm -C tutorials run start:quickstart-llms    # build + run tutorial
+
+# From tutorials/
+pnpm run build                                  # compile TS → dist/
+```
+
+## NOTES
+
+- Requires `SERPAPI_API_KEY` + `OPENAI_API_KEY` in root `.env`
+- Only one tutorial script exists — codebase is exploratory, not a library


### PR DESCRIPTION
- add a root AGENTS.md describing the repo structure, stack, commands, conventions, and anti-patterns
- add scoped AGENTS.md files for tutorials, sections, local-do, pdf-dist, and key pdf-dist subareas (chat, web, client)
- document where to make common changes in each area to improve agent and contributor navigation