### PR TITLE
ci: migrate to mise for tool version management

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,21 @@
+---
+# Based on https://github.com/marcusrbrown/containers/blob/main/.github/actions/setup/action.yaml
+name: Setup
+description: Setup build environment using mise
+
+inputs:
+  cache-version:
+    default: '0'
+    description: Cache version. Can be incremented to invalidate the cache.
+    required: false
+
+runs:
+  steps:
+    - name: Install mise
+      env:
+        MISE_VERSION: 2026.3.0 # renovate: datasource=github-releases packageName=jdx/mise
+      uses: jdx/mise-action@6d1e696aa24c1aa1bcc1adea0212707c71ab78a8 # v3.6.1
+      with:
+        version: ${{ env.MISE_VERSION }}
+
+  using: composite

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ name: CI
 
 env:
   FORCE_COLOR: true
-  NODE_VERSION: 20.20.1 # renovate: datasource=node depName=node
 
 jobs:
   build-nodejs:
@@ -19,14 +18,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Enable Corepack
-        run: corepack enable
+      - name: Setup environment
+        uses: ./.github/actions/setup
 
-      - name: Use Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          cache: pnpm
-          node-version-file: '.node-version'
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --strict-peer-dependencies
@@ -44,14 +50,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Install Poetry
-        run: pipx install poetry
+      - name: Setup environment
+        uses: ./.github/actions/setup
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - name: Cache Poetry dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          cache: poetry
-          python-version-file: 'pyproject.toml'
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
 
       - name: Install dependencies
         run: poetry install


### PR DESCRIPTION
## Summary

Replaces `actions/setup-python` and `actions/setup-node` with `jdx/mise-action`, using `mise.toml` as the single source of truth for tool versions in CI — matching local development and the [containers repo](https://github.com/marcusrbrown/containers) pattern.

## Changes

- **Add `.github/actions/setup/` composite action** — wraps `jdx/mise-action` to install all tools (Python, Node.js, pnpm, Poetry) from `mise.toml`
- **Rewrite CI workflow** to use the new setup action instead of `actions/setup-python`, `actions/setup-node`, `pipx install poetry`, and `corepack enable`
- **Add explicit caching** for pnpm store and Poetry virtualenv via `actions/cache`
- **Remove unused `NODE_VERSION` env var**

## Why

PR #309 (Renovate Python update) fails because `actions/setup-python` reads the Python version from `pyproject.toml`, which can diverge from `poetry.lock`. With mise, tool versions come from `mise.toml` (single source of truth), decoupling CI tool management from Python package constraints.

## Related

- Fixes the CI pattern that causes #309 to fail
- Follows the setup pattern from [marcusrbrown/containers](https://github.com/marcusrbrown/containers/blob/main/.github/actions/setup/action.yaml)