### PR TITLE
fix(renovate): fix postUpgradeTasks config causing artifact failures

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,18 +11,12 @@
     },
   ],
   postUpgradeTasks: {
-    commands: ['pnpm format', 'poetry lock'],
+    commands: ['poetry lock'],
     executionMode: 'branch',
+    fileFilters: ['poetry.lock'],
     installTools: {
-      pnpm: {},
-      python: {},
+      python: {constraint: '3.14'},
       poetry: {},
-      packageRules: [
-        {
-          matchCategories: ['python'],
-          constraint: '3.14',
-        },
-      ],
     },
   },
 }


### PR DESCRIPTION
## Summary

Fixes the `renovate/artifacts` = `Artifact file update failure` status on every Python dep and action update PR.

## Root cause

The `postUpgradeTasks` config had three problems:

1. **`pnpm format` fails on Python-only updates** — Renovate installs pnpm via `installTools` but doesn't install `node_modules`, so Prettier isn't available. Every Python dep PR (#531, #532, #533, etc.) and action update PR (#522) fails immediately.

2. **Invalid `packageRules` inside `installTools`** — `packageRules` is a top-level Renovate key. Nested inside `installTools`, it's ignored and the Python constraint was lost.

3. **Missing `fileFilters`** — without it, Renovate doesn't properly scope which generated files to commit.

## Fix

```diff
  postUpgradeTasks: {
-   commands: ['pnpm format', 'poetry lock'],
+   commands: ['poetry lock'],
    executionMode: 'branch',
+   fileFilters: ['poetry.lock'],
    installTools: {
-     pnpm: {},
-     python: {},
-     poetry: {},
-     packageRules: [
-       {
-         matchCategories: ['python'],
-         constraint: '3.14',
-       },
-     ],
+     python: {constraint: '3.14'},
+     poetry: {},
    },
  },
```

- **`pnpm format` removed** — CI already runs `pnpm check-format` as a required check, making this redundant. And it can't reliably work in Renovate's postUpgrade context without full `node_modules`.
- **`pnpm` removed from `installTools`** — not needed without `pnpm format`.
- **`python: {constraint: '3.14'}`** — explicitly pins the Python version for `poetry lock`.
- **`fileFilters: ['poetry.lock']`** — tells Renovate to commit only the regenerated lock file.

## Affected PRs

These all have `renovate/artifacts` = failure that will clear once Renovate rebases after this merges:
#492, #522, #523, #524, #531, #532, #533 (and older: #344, #271, #269, #267, #265)