### PR TITLE
fix(renovate): scope postUpgradeTasks to poetry manager only

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,14 +9,17 @@
       matchDepNames: ['python'],
       allowedVersions: '<=3.14',
     },
-  ],
-  postUpgradeTasks: {
-    commands: ['poetry lock'],
-    executionMode: 'branch',
-    fileFilters: ['poetry.lock'],
-    installTools: {
-      python: {constraint: '3.14'},
-      poetry: {},
+    {
+      matchManagers: ['poetry'],
+      postUpgradeTasks: {
+        commands: ['poetry lock'],
+        executionMode: 'branch',
+        fileFilters: ['poetry.lock'],
+        installTools: {
+          python: {constraint: '3.14'},
+          poetry: {},
+        },
+      },
     },
-  },
+  ],
 }


### PR DESCRIPTION
## Summary

Moves `postUpgradeTasks` from top-level config into a `packageRules` entry with `matchManagers: ['poetry']`, so `poetry lock` only runs when Poetry-managed Python deps are updated.

## Problem

Top-level `postUpgradeTasks` runs for **every** Renovate update — npm deps, GitHub Actions, mise tools, etc. This means `poetry lock` (plus Python/Poetry installation via `installTools`) executes unnecessarily for Node.js dependency PRs, wasting time and potentially failing.

## Fix

```diff
- postUpgradeTasks: {
-   commands: ['poetry lock'],
-   executionMode: 'branch',
-   fileFilters: ['poetry.lock'],
-   installTools: {
-     python: {constraint: '3.14'},
-     poetry: {},
-   },
- },
+ packageRules: [
+   ...
+   {
+     matchManagers: ['poetry'],
+     postUpgradeTasks: {
+       commands: ['poetry lock'],
+       executionMode: 'branch',
+       fileFilters: ['poetry.lock'],
+       installTools: {
+         python: {constraint: '3.14'},
+         poetry: {},
+       },
+     },
+   },
+ ],
```

`postUpgradeTasks` inside `packageRules` is supported — [pulumi/pulumi](https://github.com/pulumi/pulumi/blob/master/renovate.json5) uses the same pattern to scope `gomod tidy` to Go updates only.