### PR TITLE
feat: configure Copilot coding agent

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+# Copilot Instructions
+
+Read `AGENTS.md` at the repository root first — it has the full project map, structure, conventions, commands, and anti-patterns. Everything below supplements it.
+
+## Verification (run before every commit)
+
+```bash
+pnpm check-format    # Prettier — must pass
+pnpm build           # all workspaces — must pass
+poetry install       # Python deps — must pass
+```
+
+If you change Python dependency versions in any `pyproject.toml`, also run `poetry lock` to regenerate the lock file.
+
+## Hard rules
+
+### TypeScript
+
+- `@tsconfig/strictest` is active — no `any`, no `@ts-ignore`, no `@ts-expect-error`
+- ESM only: use `.js` extensions in all import paths (`import {foo} from './bar.js'`)
+- Module system is `nodenext` — no CommonJS, no `require()`
+
+### Python
+
+- Python `^3.14` via Poetry — each subdirectory has its own `pyproject.toml`
+- Application code imports are **stale** — deps were upgraded to pydantic v2, openai v1, langchain 0.3, chromadb 1.x but the code still uses old APIs. Check actual import paths against current package versions before writing new code.
+
+### Package managers
+
+- **pnpm 10 only** for JS/TS — never use npm or yarn
+- **Poetry only** for Python — never use pip directly
+- pnpm settings live in `pnpm-workspace.yaml`, not `.npmrc`
+
+### Formatting
+
+- Prettier: `singleQuote: true`, `bracketSpacing: false`, `tabWidth: 2`
+- Run `pnpm format` to auto-fix before committing
+- `.svelte` files use the `svelte` parser (configured in `.prettierrc.yaml`)
+
+### Security
+
+- **Never** commit API keys, tokens, or credentials
+- `.env` files are gitignored — use `.env.template` as reference
+- Pin GitHub Actions by full SHA hash, not version tag
+
+## Tool versions
+
+All tool versions are managed by `mise.toml` — do not install Python, Node, pnpm, or Poetry through other means. Run `mise install` to get the correct versions.
+
+## What CI checks
+
+| Job           | Checks                                              |
+| ------------- | --------------------------------------------------- |
+| Build Node.js | `pnpm install` → `pnpm check-format` → `pnpm build` |
+| Build Python  | `poetry install`                                    |
+
+There are no test suites. `pnpm test` exits with an error intentionally.

--- a/.github/workflows/copilot-setup-steps.yaml
+++ b/.github/workflows/copilot-setup-steps.yaml
@@ -1,0 +1,53 @@
+---
+name: Copilot Setup Steps
+
+'on':
+  workflow_dispatch:
+  push:
+    paths: [.github/workflows/copilot-setup-steps.yaml]
+  pull_request:
+    paths: [.github/workflows/copilot-setup-steps.yaml]
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm dependencies
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
+      - name: Install Node.js dependencies
+        run: pnpm install --frozen-lockfile --strict-peer-dependencies
+
+      - name: Build Node.js workspaces
+        run: pnpm build
+
+      - name: Cache Poetry dependencies
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
+
+      - name: Install Python dependencies
+        run: poetry install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,14 @@
 # AGENTS.md
 
-**Generated:** 2026-03-23 | **Commit:** 89328ad | **Branch:** main
+**Generated:** 2026-03-25 | **Commit:** 7af32e0 | **Branch:** main
 
 ## OVERVIEW
 
 Polyglot AI/LLM experimentation monorepo — LangChain-based copilot experiments. Contains a production-ish Flask + SvelteKit PDF chat app (`course/pdf-dist`) and standalone Python/TypeScript tutorial scripts. Course/exploration code, not a shipped product.
 
-**Stack:** Python 3.11.7 (Poetry) · TypeScript 5.3 (pnpm) · Flask · SvelteKit · LangChain (old 0.0.x) · OpenAI · Pinecone · Redis · Celery · SQLAlchemy
+**Stack:** Python 3.14 (Poetry) · TypeScript 5.3 (pnpm 10) · Flask · SvelteKit · LangChain 0.3 · OpenAI v1 · Pinecone · Redis · Celery · SQLAlchemy
+
+**Tooling:** mise (tool version manager) · Renovate (automated dependency updates)
 
 ## STRUCTURE
 
@@ -24,7 +26,8 @@ copiloting/
 ├── copiloting/          # Empty Python stub (ignore)
 ├── package.json         # Root pnpm workspace + Prettier scripts
 ├── pyproject.toml       # Root Poetry config — defines CLI entry points
-├── pnpm-workspace.yaml  # JS workspaces: tutorials, course/pdf-dist/client
+├── pnpm-workspace.yaml  # JS workspaces + pnpm settings (replaces .npmrc)
+├── mise.toml            # Tool versions: python, node, pnpm, poetry
 └── tsconfig.json        # Extends @tsconfig/strictest, ES2022, nodenext
 ```
 
@@ -44,23 +47,28 @@ copiloting/
 | Celery worker           | `course/pdf-dist/app/celery/worker.py`                     |
 | Env vars                | `.env.template` (safe) / `.env` (real keys — do not share) |
 | CI pipeline             | `.github/workflows/ci.yaml`                                |
+| Tool versions           | `mise.toml`                                                |
+| Renovate config         | `.github/renovate.json5`                                   |
 
 ## CONVENTIONS
 
+- **Tool management**: mise manages all tool versions (Python, Node, pnpm, Poetry) — see `mise.toml`
 - **TypeScript**: Extends `@tsconfig/strictest` — maximum strictness; no `any`, no suppression
 - **Module format**: `"module": "nodenext"` — requires `.js` extensions in TS imports
 - **Prettier**: `singleQuote: true`, `bracketSpacing: false`, `tabWidth: 2`; `.svelte` files use svelte parser
-- **Python**: pinned to `3.11.7`, managed by Poetry; each subdirectory is an independent Poetry project
-- **Package manager**: pnpm `≥7` only for JS/TS — never npm or yarn in this repo
+- **Python**: `^3.14`, managed by Poetry; each subdirectory is an independent Poetry project
+- **Package manager**: pnpm 10 only for JS/TS — never npm or yarn in this repo
+- **pnpm settings**: Configured in `pnpm-workspace.yaml` (not `.npmrc`)
 - **Line endings**: LF, enforced by EditorConfig across all files
 - **SvelteKit path aliases**: `$c` → `src/components`, `$s` → `src/store`, `$api` → `src/api/axios.js`
+- **GitHub Actions**: Pin actions by full SHA hash (security practice); Renovate updates them
 
 ## ANTI-PATTERNS
 
 - **`.env` contains real committed secrets** — never copy or commit actual API keys
-- **LangChain versions are ancient**: JS at `0.0.212`, Python at `0.0.352` — modern LangChain docs don't apply; imports and APIs are completely different
 - **No tests** — `pnpm test` intentionally exits with error; no pytest setup exists
 - **`copiloting/__init__.py`** is an empty stub — not a real importable package
+- **Python code imports are stale** — deps were recently upgraded (pydantic v2, openai v1, langchain 0.3, chromadb 1.x) but application code has not been updated to match new APIs
 
 ## COMMANDS
 
@@ -71,25 +79,21 @@ pnpm build                           # build all workspaces recursively
 pnpm check-format                    # Prettier format check (runs in CI)
 pnpm format                          # Prettier auto-fix
 
-# Run TypeScript tutorial (requires SERPAPI_API_KEY + OPENAI_API_KEY in .env)
-pnpm -C tutorials run start:quickstart-llms
-
-# SvelteKit dev server
-pnpm -C course/pdf-dist/client run dev
-
 # From repo root — Python
 poetry install                       # install all Python deps
-poetry run agents                    # SQL agent demo (course/sections/agents)
-poetry run course                    # LangChain chain demo (course/sections/chain)
-poetry run facts                     # facts RAG demo (course/sections/facts)
-poetry run facts-create-embeddings   # create Chroma embeddings
-poetry run tchat                     # terminal chat demo
+poetry lock                          # regenerate lock file
+
+# Verification (run before committing)
+pnpm check-format                    # must pass
+pnpm build                           # must pass
+poetry install                       # must pass
 ```
 
 ## NOTES
 
 - Renovate auto-updates deps; CI action pins use full SHA hashes (security practice)
+- Renovate `postUpgradeTasks` runs `poetry lock` for Python dep updates (scoped to poetry manager)
 - CI runs format check + build for Node, `poetry install` only for Python (no lint/test)
-- `poetry.lock` (388KB) covers all Poetry groups including `pdf-dist` and `sections` path deps
+- `poetry.lock` covers all Poetry groups including `pdf-dist` and `sections` path deps
 - Both `pnpm` and `poetry` run independently — no cross-language tooling bridge
 - `course/pdf-dist` has its own `dump.rdb` and `instance/sqlite.db` — local dev state artifacts


### PR DESCRIPTION
## Summary

Configures GitHub Copilot coding agent for this repo so it can autonomously work on issues and PRs with a correct environment.

## Files

### `.github/workflows/copilot-setup-steps.yaml` (new)
Setup workflow that mirrors the CI pipeline — Copilot runs this before starting work:
1. Checkout + mise (installs Python 3.14, Node 20, pnpm 10, Poetry)
2. pnpm install + build (all workspaces — Prettier/ESLint available)
3. Poetry install (all Python deps)
4. Caching for both pnpm store and Poetry venv

Job name is `copilot-setup-steps` (required by Copilot). Action SHAs match CI exactly.

### `.github/copilot-instructions.md` (new)
Global instructions for all Copilot interactions:
- References `AGENTS.md` as source of truth (no duplication)
- Verification commands to run before every commit
- Hard rules: TypeScript strictness, ESM imports, pnpm/Poetry only, security
- Stale imports warning (deps upgraded but code not yet updated)

### `AGENTS.md` (updated)
Brought current with recent changes:
- Python 3.11.7 → 3.14
- LangChain 0.0.x → 0.3, OpenAI v0.28 → v1, pydantic v1 → v2
- pnpm 8 → 10 (settings in pnpm-workspace.yaml)
- Added mise tooling, Renovate postUpgradeTasks docs
- Added stale-imports anti-pattern warning