### PR TITLE
docs: update subdirectory AGENTS.md for current dep versions

### DIFF
--- a/course/pdf-dist/AGENTS.md
+++ b/course/pdf-dist/AGENTS.md
@@ -42,7 +42,7 @@ pdf-dist/
 ## ANTI-PATTERNS
 
 - Do not use `pip install` — this is a Poetry project (`poetry install` from repo root)
-- Flask app uses `langchain==0.0.x` — modern langchain chain APIs don't apply here
+- Python deps were upgraded (langchain 0.3, openai v1, pydantic v2) but application code still uses old import paths — check actual imports before writing new code
 - `instance/sqlite.db` and `dump.rdb` are local dev artifacts — not production state
 
 ## COMMANDS

--- a/course/pdf-dist/app/chat/AGENTS.md
+++ b/course/pdf-dist/app/chat/AGENTS.md
@@ -55,11 +55,11 @@ chat/
 - Component names are stored in the `Conversation` DB record; reused on subsequent messages to same conversation
 - `ChatArgs` carries `conversation_id`, `pdf_id`, `metadata`, `streaming: bool`
 - `TraceableChain` + `StreamableChain` applied as mixins before `ConversationalRetrievalChain` in MRO
-- langchain 0.0.352 Python — use `from langchain.chat_models import ChatOpenAI`, NOT `from langchain_openai import ...`
+- **Stale imports**: deps are now langchain `^0.3` / openai `^1.10` / pydantic `^2.10`, but the code still uses old `0.0.352`-era imports. The correct modern imports (`from langchain_openai import ChatOpenAI`) are installed but the code hasn't been migrated yet.
 
 ## ANTI-PATTERNS
 
-- Do not import from `langchain_openai`, `langchain_community`, etc. — those packages don't exist at `0.0.352`
+- Do not mix old and new langchain import styles in the same file — either migrate a file fully or leave it on old imports
 - Do not bypass `build_chat()` — component selection + persistence must go through it
 - Do not call DB layer directly from chat — use `app.web.api` functions
 

--- a/course/sections/AGENTS.md
+++ b/course/sections/AGENTS.md
@@ -38,14 +38,14 @@ sections/
 
 ## CONVENTIONS
 
-- All modules use `langchain==0.0.352` (Python) — not compatible with modern langchain 0.1+/0.3+ APIs
+- **Stale imports**: deps are now langchain `^0.3`, chromadb `^1.0`, pydantic `^2.10`, but code still uses old `0.0.352`-era imports — needs migration
 - `load_dotenv()` called at module init — reads from root `.env`
 - Each module is runnable via `poetry run <script>` from repo root (defined in root `pyproject.toml`)
 - SQLite DB for agents demo: `agents/db.sqlite`
 
 ## ANTI-PATTERNS
 
-- Do not use modern langchain imports (`from langchain_openai import ...`) — only `langchain.llms.openai`, `langchain.chat_models`, etc. work at `0.0.352`
+- Do not mix old and new langchain import styles in the same file — either migrate fully or leave on old imports
 - Do not add new Poetry scripts here — they're declared in root `pyproject.toml`, not this `pyproject.toml`
 
 ## COMMANDS


### PR DESCRIPTION
## Summary

Updates 3 stale subdirectory AGENTS.md files to reflect the Python 3.14 dep upgrade from #565.

## Changes

| File | Update |
|------|--------|
| `course/pdf-dist/AGENTS.md` | `langchain==0.0.x` → deps upgraded, code uses old imports |
| `course/pdf-dist/app/chat/AGENTS.md` | Updated import guidance — deps are modern (`^0.3`), code still uses `0.0.352`-era imports |
| `course/sections/AGENTS.md` | Updated langchain + chromadb version refs, same stale-import warning |

All 3 files now accurately describe the disconnect: **deps are modern, code imports are stale and need migration**.

5 files unchanged (root, app/web, client, local-do, tutorials) — already accurate.