### PR TITLE
fix(pdf-dist): align pdfjs runtime assets after #584

### DIFF
--- a/course/pdf-dist/client/src/app.html
+++ b/course/pdf-dist/client/src/app.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <link
-      href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.10.38/pdf_viewer.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf_viewer.min.css"
       rel="stylesheet"
     />
     <meta name="viewport" content="width=device-width" />

--- a/course/pdf-dist/client/src/components/PdfViewer.svelte
+++ b/course/pdf-dist/client/src/components/PdfViewer.svelte
@@ -3,7 +3,7 @@
   import * as pdfjs from 'pdfjs-dist';
 
   pdfjs.GlobalWorkerOptions.workerSrc =
-    'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.5.141/pdf.worker.min.js';
+    'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.2.67/pdf.worker.min.mjs';
 
   export let url = '';
   let canvasContainer: HTMLDivElement;


### PR DESCRIPTION
## Summary
- fix the runtime asset mismatch left behind after `#584` merged by aligning the PDF.js worker URL with `pdfjs-dist@4.2.67`
- align the CDN viewer CSS to `4.2.67` as well so the browser-loaded assets match the installed library version
- keep the scope narrow to the missed runtime compatibility issue; `#584` already handled the build-target CI failure

## Testing
- `pnpm -C course/pdf-dist/client run build`
- `pnpm build`
- `pnpm check-format`
- `poetry install`

## Post-Deploy Monitoring & Validation
- No additional operational monitoring required: this only corrects static frontend asset URLs for the existing PDF viewer so runtime compatibility matches the already-merged `pdfjs-dist` v4 dependency update.