### PR TITLE
fix(renovate): move installTools to top-level postUpgradeTasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,17 +2,12 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['github>marcusrbrown/renovate-config#v4'],
   constraints: {python: '3.14'},
-  packageRules: [
-    {matchDepNames: ['python'], allowedVersions: '<=3.14'},
-    {
-      matchManagers: ['poetry'],
-      postUpgradeTasks: {
-        commands: ['poetry lock'],
-        executionMode: 'branch',
-        fileFilters: ['poetry.lock'],
-        installTools: {python: {}, poetry: {}},
-      },
-    },
-  ],
+  packageRules: [{matchDepNames: ['python'], allowedVersions: '<=3.14'}],
+  postUpgradeTasks: {
+    commands: ['poetry lock'],
+    executionMode: 'branch',
+    fileFilters: ['poetry.lock'],
+    installTools: {python: {}, poetry: {}},
+  },
   rebaseWhen: 'behind-base-branch',
 }


### PR DESCRIPTION
## Summary

Fixes #608 — Renovate config validation error blocking all PRs.

## Root cause

`installTools` is only valid at **top-level** `postUpgradeTasks`, not inside `packageRules[].postUpgradeTasks`. Confirmed by inspecting the [Renovate JSON schema](https://docs.renovatebot.com/renovate-schema.json):

```
Top-level postUpgradeTasks properties:
  commands, dataFileTemplate, description, executionMode,
  fileFilters, installTools, workingDirTemplate

packageRules[].postUpgradeTasks:
  (no sub-properties defined in schema)
```

## Fix

Moved `postUpgradeTasks` (with `installTools`) from inside `packageRules` to top level. `poetry lock` now runs for all updates, but is a no-op when `pyproject.toml` hasn't changed — `fileFilters: ['poetry.lock']` ensures only actual lock file changes are committed.

Closes #608